### PR TITLE
Install from rOpenSci GitHub repository

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
 
 ```{r eval=FALSE}
 install.packages("devtools")
-devtools::install_github("sckott/ropkgs")
+devtools::install_github("ropensci/ropkgs")
 ```
 
 ```{r}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ropkgs
 
 ```r
 install.packages("devtools")
-devtools::install_github("sckott/ropkgs")
+devtools::install_github("ropensci/ropkgs")
 ```
 
 


### PR DESCRIPTION
This is a very minor change to the README, giving the rOpenSci repository.
